### PR TITLE
Added optional location parameter to assertHttpRedirect.

### DIFF
--- a/django_test_mixins.py
+++ b/django_test_mixins.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.core.cache import cache
 
+import urlparse
+
 
 class HttpCodeTestCase(TestCase):
     # TODO: this should be a private method.
@@ -30,7 +32,7 @@ class HttpCodeTestCase(TestCase):
             if location.startswith("http://testserver/"):
                 absolute_location = location
             else:
-                absolute_location = "http://testserver/%s" + location
+                absolute_location = urlparse.urljoin("http://testserver/",  location)
 
             self.assertEqual(response['Location'], absolute_location)
 


### PR DESCRIPTION
This parameter is used to assert that the request was redirected to
the expected location.

I'm not familiar with mock, so I wasn't able to add a unittest. If anyone can give me pointers as to how that coud be done, I'll add it in.
