### PR TITLE
Add six and fix urlparse import for Python 3.

### DIFF
--- a/django_test_mixins.py
+++ b/django_test_mixins.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.core.cache import cache
 
-import urlparse
+from six.moves.urllib.parse import urlparse
 
 
 class HttpCodeTestCase(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(name='django_test_mixins',
       py_modules=['django_test_mixins'],
       classifiers=[
           'License :: OSI Approved :: BSD License'
-      ]
+      ],
+      install_requires=['six'],
 )


### PR DESCRIPTION
Hey @Wilfred! This gets Python 3 working :)